### PR TITLE
fix: 前日比の取得方法を変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,11 +30,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
         Exception: メッセージ送信時または処理中にエラーが発生した場合に例外をスローします。
     """
     current_billing_data = get_billing_data()
-    prev_billing_data = get_billing_data(single_date=True)
 
-    total_billing_info, service_billings, account_billings = process_billing_data(
-        current_billing_data, prev_billing_data
-    )
+    total_billing_info, service_billings, account_billings = process_billing_data(current_billing_data)
 
     # 投稿用のメッセージを作成する
     (title, detail) = create_message(

--- a/template.yaml
+++ b/template.yaml
@@ -210,11 +210,8 @@ Resources:
                   Exception: メッセージ送信時または処理中にエラーが発生した場合に例外をスローします。
               """
               current_billing_data = get_billing_data()
-              prev_billing_data = get_billing_data(single_date=True)
           
-              total_billing_info, service_billings, account_billings = process_billing_data(
-                  current_billing_data, prev_billing_data
-              )
+              total_billing_info, service_billings, account_billings = process_billing_data(current_billing_data)
           
               # 投稿用のメッセージを作成する
               (title, detail) = create_message(


### PR DESCRIPTION
## What?
前日比の取得方法を変更
- 実行月の1日から実行日の取得を "MONTHLY" から "DAILY" に変更
  - API のアクセスが 1回にまとめられた
- AmortizedCost から UnblendedCost に変更
- 不要になったコードを削除

## Why?
前日比 の情報が実際にメッセージで届く表示と差分があるため

## See also [Optional]
- [AWS 利用料金の前日比の金額確認](https://www.notion.so/hashup/AWS-1cf615bb538a8026880fc513d1e7b829?pvs=24)

